### PR TITLE
update to remove help text when help modal closes

### DIFF
--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -129,11 +129,11 @@ $(document).ready(function () {
   $("#help-btn").click(function () {
       console.log("boo")
       resetModalInputs();
-      var p1 = '<p><button class="btn"><i class="material-icons">search</i></button>Search the Movie Database for the Movie Name in the Search Bar</p>';
-      var p2 = '<p><button class="btn"><i class="material-icons">add_circle</i></button>Add current Movie to the Favourites Collection</p>';
-      var p3 = '<p><button class="btn"><i class="material-icons">remove_circle</i></button>Delete current Movie to the Favourites Collection</p>';
-      var p4 = '<p><button class="btn"><i class="material-icons">view_list</i></button>View the Favourites Collection</p>';
-      var p5 = '<p><button class="btn"><i class="material-icons">delete_forever</i></button>Delete the Favourites Collection</p>';
+      var p1 = '<p class="help-mdl"><button class="btn"><i class="material-icons">search</i></button>Search the Movie Database for the Movie Name in the Search Bar</p>';
+      var p2 = '<p class="help-mdl"><button class="btn"><i class="material-icons">add_circle</i></button>Add current Movie to the Favourites Collection</p>';
+      var p3 = '<p class="help-mdl"><button class="btn"><i class="material-icons">remove_circle</i></button>Delete current Movie to the Favourites Collection</p>';
+      var p4 = '<p class="help-mdl"><button class="btn"><i class="material-icons">view_list</i></button>View the Favourites Collection</p>';
+      var p5 = '<p class="help-mdl"><button class="btn"><i class="material-icons">delete_forever</i></button>Delete the Favourites Collection</p>';
       $("#modal-header").text("Help");
       $(".modal-close").text('Cancel')
 
@@ -454,7 +454,7 @@ function resetInputs() {
   $("#review2-title").text("");
 
   $(".review-list").hide();
-
+  $(".help-mdl").remove();
   $(".ml-btn").remove();
   $(".no-movie").remove();
 
@@ -477,6 +477,7 @@ function resetModalInputs() {
   $("#modal-header").text("");
   $(".ml-btn").remove();
   $(".fav-btn").remove();
+  $(".help-mdl").remove();
 }
 
 // Removes all favourites from local storage


### PR DESCRIPTION
Remove help text from help modal after modal closes.

This stops the help text showing when the favourites modal or the find movies modal displays